### PR TITLE
Improve 3D plot and video for variable height model

### DIFF
--- a/drake/examples/RobustBalancing/VariableHeightPointMass2D.m
+++ b/drake/examples/RobustBalancing/VariableHeightPointMass2D.m
@@ -76,25 +76,100 @@ classdef VariableHeightPointMass2D < NStepCapturabilitySOSSystem
       title('V(0,x)')
       
       % 3d plot for z0dot = 0
-      figure(n * 10 + 3);
-      VsolSlice = subs(Vsol, [v(2); t], [0; 0]);
-      grid_size = 20;
-      [q1s, v1s, q2s] = meshgrid(...
+      hFig = figure(n * 10 + 3);
+      clf;
+      variableHeightContour3D(Vsol, h_X, R_diag, t, x);
+      
+      % video of rotating ROA
+      create_video = true;
+      if create_video
+        writer = VideoWriter([class(obj) '_V' num2str(n)], 'MPEG-4');
+        set(writer, 'Quality', 90)
+        
+        open(writer);
+        dtheta = 1;
+        for i = 1 : 360 / dtheta
+          camorbit(dtheta, 0); drawnow;
+          writeVideo(writer, getframe(hFig));
+        end
+        close(writer);
+      end
+    end
+  end
+  
+  methods (Static)
+    function variableHeightContour3D(Vsol, h_X, R_diag, t, x)
+      colormap summer;
+      
+      q = x(1 : 2);
+      v = x(3 : 4);
+      
+      % uniform grid
+      grid_size = 40;
+      [q1s_grid, v1s_grid, q2s_grid] = meshgrid(...
         linspace(-R_diag(1), R_diag(1), grid_size),...
         linspace(-R_diag(3), R_diag(3), grid_size),...
         linspace(-R_diag(2), R_diag(2), grid_size));
-      Vs = full(msubs(VsolSlice, [q(1); v(1); q(2)], [q1s(:)';v1s(:)'; q2s(:)']));
-      Vs = reshape(Vs, grid_size, grid_size, grid_size);
       
-      % plot surface where constraint_left_hand_side is zero
-      p = patch(isosurface(q1s, v1s, q2s, Vs, 0), 'FaceColor', 'r', 'EdgeColor', 'none');
-      patch(isocaps(q1s,v1s,q2s,Vs,0), 'FaceColor', 'interp', 'EdgeColor', 'none');
+      h_Xslice = subs(h_X, [v(2); t], [0; 0]);
+      h_Xs = full(msubs(h_Xslice, [q(1); v(1); q(2)], [q1s_grid(:)';v1s_grid(:)'; q2s_grid(:)']));
+      h_Xs = reshape(h_Xs, grid_size, grid_size, grid_size);
       
-      % graph formatting
-      isonormals(q1s,v1s,q2s,Vs, p)
+      VsolSlice = subs(Vsol, [v(2); t], [0; 0]);
+      Vs_grid = reshape(full(msubs(VsolSlice, [q(1); v(1); q(2)], [q1s_grid(:)';v1s_grid(:)'; q2s_grid(:)'])), grid_size, grid_size, grid_size);
+      
+      q1s = q1s_grid;
+      v1s = v1s_grid;
+      q2s = q2s_grid;
+      
+      intersect_with_ellipsoid = true;
+      if intersect_with_ellipsoid
+        mask = h_Xs < 0;
+        
+        % x' * A * x = 1 - h_X
+        % (s * x)' * A * (s * x) = 1
+        % s^2 * (1 - h_X) = 1
+        % s = sqrt(1 / (1 - h_X))
+        s = sqrt(1 / (1 - h_Xs));
+        q1s(mask) = s(mask) .* q1s_grid(mask);
+        v1s(mask) = s(mask) .* v1s_grid(mask);
+        q2s(mask) = s(mask) .* q2s_grid(mask);
+      end
+      
+      Vs = reshape(full(msubs(VsolSlice, [q(1); v(1); q(2)], [q1s(:)';v1s(:)'; q2s(:)'])), grid_size, grid_size, grid_size);
+      
+      % actual zero-level set patch
+      c = colormap;
+      p_V = patch(isosurface(q1s, v1s, q2s, Vs, 0), 'FaceColor', c(1, :), 'EdgeColor', 'none', 'AmbientStrength', 0.7);
+      
+      % patch that closes the region
+      p_V_caps = patch(isocaps(q1s,v1s,q2s,Vs,0), 'FaceColor', 'interp', 'EdgeColor', 'none', 'AmbientStrength', 0.7);
+      
+      % faint ellipsoid
+      patch(isosurface(q1s, v1s, q2s, h_Xs, 0), 'FaceColor', 'b', 'EdgeColor', 'none', 'FaceAlpha', 0.03);       
+      
+      % use V values to get better normals
+      isonormals(q1s_grid,v1s_grid,q2s_grid,Vs_grid, p_V);
+      
+      if intersect_with_ellipsoid
+        % use h_Xs normals for caps
+        isonormals(q1s_grid,v1s_grid,q2s_grid,h_Xs, p_V_caps);
+        
+        % draw intersection between ellipsoid boundary and V zero-level set
+        p_V_caps_boundary = patch(isocaps(q1s,v1s,q2s,Vs,0), 'FaceColor', 'none');
+        Vs_caps = full(msubs(VsolSlice, [q(1); v(1); q(2)], p_V_caps_boundary.Vertices'));
+        p_V_caps_boundary.FaceVertexCData = nan(length(Vs_caps), 3);
+        p_V_caps_boundary.FaceVertexCData(Vs_caps < 5e-3, :) = 0;
+        p_V_caps_boundary.EdgeColor = 'interp';
+        p_V_caps_boundary.LineWidth = 2;
+      end
+      
+      % formatting
       daspect([1 1 1])
-      view(3)
-      camlight; lighting phong
+      view(-37.5, 35)
+      light('Style', 'Local', 'Position', [2 0 -2]);
+      camlight
+      lighting gouraud
       xlabel('q_1'); ylabel('v_1'); zlabel('q_2');
       grid on;
       box on;
@@ -105,20 +180,7 @@ classdef VariableHeightPointMass2D < NStepCapturabilitySOSSystem
       ax.ZTick = linspace(-R_diag(2), R_diag(2), 5);
       axis vis3d
       zoom(1.4)
-      
-      create_video = true;
-      if create_video
-        writer = VideoWriter([class(obj) '_V' num2str(n) '.avi'], 'MPEG-4');
-        set(writer, 'Quality', 90)
-        
-        open(writer);
-        dtheta = 1;
-        for i = 1 : 360 / dtheta
-          camorbit(dtheta, 0); drawnow;
-          writeVideo(writer, getframe(gcf()));
-        end
-        close(writer);
-      end
+      colorbar
     end
   end
 end

--- a/drake/examples/RobustBalancing/variableHeightPointMass2DNStepCapturability.m
+++ b/drake/examples/RobustBalancing/variableHeightPointMass2DNStepCapturability.m
@@ -1,7 +1,7 @@
 function variableHeightPointMass2DNStepCapturability(n)
 
 g = 1;
-step_max = .7;
+step_max = .3;
 step_time = 0.3;
 f_max = 1.5 * g;
 z_nom = 1;
@@ -16,7 +16,7 @@ end
 options.degree = 6;
 
 % R_diag = 2 * ones(1, model.num_states);
-R_diag = [2, 0.2, 2, 2];
+R_diag = [2, 0.5, 2, 2];
 
 goal_radius = 0.01;
 target = @(x) goal_radius^2 - x'*x;


### PR DESCRIPTION
Improved the 3D plot showing a slice at zdot = 0 of the 1-step ROA (based on v only, not w) for the variable height model. Looks pretty cool now:

https://www.dropbox.com/s/6lnlo5usq68sjiy/VariableHeightPointMass2D_V1.mp4?dl=0